### PR TITLE
Replace ed command with sed in beginner's helpers

### DIFF
--- a/beginner/helpers.sh
+++ b/beginner/helpers.sh
@@ -66,16 +66,12 @@ init_simple_repo () {
     git add schedule_day1.txt && git commit -m "Add schedule_day1"
     git add schedule_day2.txt && git commit -m "Add schedule_day2"
 
-    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     sed -i '/program/a 09:00-11:00: Poster session' schedule_day1.txt > /dev/null
     sed -i '/program/a 09:00-11:00: Poster session' schedule_day2.txt > /dev/null
     git add * && git commit -m "Add poster sessions in the morning"
 
     sed -i '/session/a 11:00-11:15: Coffee break' schedule_day1.txt > /dev/null
     sed -i '/session/a 11:00-11:15: Coffee break' schedule_day2.txt > /dev/null
-    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "Add coffee break"
 
     echo ""
@@ -100,8 +96,6 @@ init_simple_repo_remote () {
     git checkout -b "updated_schedules"
     sed -i '/break/a 11:15-12:15: Talk professor A.' schedule_day1.txt > /dev/null
     sed -i '/break/a 11:15-12:15: Talk professor B.' schedule_day2.txt > /dev/null
-    #printf "/break/\na\n11:15-12:15: Talk professor A.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    #printf "/break/\na\n11:15-12:15: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "update schedules"
 
     # Dynamically get the default branch name and switch to it
@@ -117,8 +111,6 @@ init_repo () {
 
     sed -i '/break/a 11:15-12:15: Workshop ice crystal formation' schedule_day1.txt > /dev/null
     sed -i '/break/a 11:15-12:15: Workshop secondary ice' schedule_day2.txt > /dev/null
-    #printf "/break/\na\n11:15-12:15: Workshop ice crystal formation\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    #printf "/break/\na\n11:15-12:15: Workshop secondary ice\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "Add workshops"
 
     sed  's/Poster session/Talk professor C./g' schedule_day1.txt > schedule_day1_tmp.txt
@@ -155,15 +147,12 @@ init_repo_remote () {
 
     # Edit schedule_day1.txt
     sed -i '/program/a 09:00-11:00: Poster session' schedule_day1.txt > /dev/null
-    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add poster sessions in the morning"
 
     sed -i '/session/a 11:00-11:15: Coffee break' schedule_day1.txt > /dev/null
-    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add coffee breaks"
 
     sed -i "/break/a 11:15-12:15: Talk professor A.\n12:15-13:30: Lunch\n13:30-15:00: Workshop\n15:00-16:00: Talk professor B." schedule_day1.txt > /dev/null
-    #printf "/break/\na\n11:15-12:15: Talk professor A.\n12:15-13:30: Lunch\n13:30-15:00: Workshop\n15:00-16:00: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add rest of daily program"
 
     cd ..

--- a/beginner/helpers.sh
+++ b/beginner/helpers.sh
@@ -66,12 +66,16 @@ init_simple_repo () {
     git add schedule_day1.txt && git commit -m "Add schedule_day1"
     git add schedule_day2.txt && git commit -m "Add schedule_day2"
 
-    printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
+    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
+    sed -i '/program/a 09:00-11:00: Poster session' schedule_day1.txt > /dev/null
+    sed -i '/program/a 09:00-11:00: Poster session' schedule_day2.txt > /dev/null
     git add * && git commit -m "Add poster sessions in the morning"
 
-    printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
+    sed -i '/session/a 11:00-11:15: Coffee break' schedule_day1.txt > /dev/null
+    sed -i '/session/a 11:00-11:15: Coffee break' schedule_day2.txt > /dev/null
+    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "Add coffee break"
 
     echo ""
@@ -94,8 +98,10 @@ init_simple_repo_remote () {
     git clone conference_planning conference_planning_remote
     cd conference_planning_remote
     git checkout -b "updated_schedules"
-    printf "/break/\na\n11:15-12:15: Talk professor A.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    printf "/break/\na\n11:15-12:15: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
+    sed -i '/break/a 11:15-12:15: Talk professor A.' schedule_day1.txt > /dev/null
+    sed -i '/break/a 11:15-12:15: Talk professor B.' schedule_day2.txt > /dev/null
+    #printf "/break/\na\n11:15-12:15: Talk professor A.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    #printf "/break/\na\n11:15-12:15: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "update schedules"
 
     # Dynamically get the default branch name and switch to it
@@ -109,8 +115,10 @@ init_simple_repo_remote () {
 init_repo () {
     init_simple_repo &> /dev/null
 
-    printf "/break/\na\n11:15-12:15: Workshop ice crystal formation\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
-    printf "/break/\na\n11:15-12:15: Workshop secondary ice\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
+    sed -i '/break/a 11:15-12:15: Workshop ice crystal formation' schedule_day1.txt > /dev/null
+    sed -i '/break/a 11:15-12:15: Workshop secondary ice' schedule_day2.txt > /dev/null
+    #printf "/break/\na\n11:15-12:15: Workshop ice crystal formation\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    #printf "/break/\na\n11:15-12:15: Workshop secondary ice\n.\nw\nq\n" | ed -s schedule_day2.txt > /dev/null
     git add * && git commit -m "Add workshops"
 
     sed  's/Poster session/Talk professor C./g' schedule_day1.txt > schedule_day1_tmp.txt
@@ -146,13 +154,16 @@ init_repo_remote () {
     git add schedule_day1.txt && git commit -m "Add schedule_day1"
 
     # Edit schedule_day1.txt
-    printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    sed -i '/program/a 09:00-11:00: Poster session' schedule_day1.txt > /dev/null
+    #printf "/program/\na\n09:00-11:00: Poster session\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add poster sessions in the morning"
 
-    printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    sed -i '/session/a 11:00-11:15: Coffee break' schedule_day1.txt > /dev/null
+    #printf "/session/\na\n11:00-11:15: Coffee break\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add coffee breaks"
 
-    printf "/break/\na\n11:15-12:15: Talk professor A.\n12:15-13:30: Lunch\n13:30-15:00: Workshop\n15:00-16:00: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
+    sed -i "/break/a 11:15-12:15: Talk professor A.\n12:15-13:30: Lunch\n13:30-15:00: Workshop\n15:00-16:00: Talk professor B." schedule_day1.txt > /dev/null
+    #printf "/break/\na\n11:15-12:15: Talk professor A.\n12:15-13:30: Lunch\n13:30-15:00: Workshop\n15:00-16:00: Talk professor B.\n.\nw\nq\n" | ed -s schedule_day1.txt > /dev/null
     git add * && git commit -m "Add rest of daily program"
 
     cd ..

--- a/beginner/tests/test_helpers.sh
+++ b/beginner/tests/test_helpers.sh
@@ -13,17 +13,24 @@ fi
 
 source "$HELPERS_PATH"
 
+# Array to store test results
+declare -a TEST_RESULTS
+
 # Function to handle test failures
 fail_test() {
-    echo -e "\033[31m\033[1m$1: FAIL\033[0m"
-    exit 1
+    TEST_RESULTS+=("$1: \033[31m\033[1mFAIL\033[0m")
+}
+
+# Function to handle test successes
+pass_test() {
+    TEST_RESULTS+=("$1: \033[32m\033[1mPASS\033[0m")
 }
 
 # Test reset function
 echo "Testing reset function..."
 reset_output=$(reset)
-if [[ "$reset_output" == *"restore clean working directory"* ]]; then
-    echo -e "\033[32m\033[1mreset function: PASS\033[0m"
+if [[ "$reset_output" == *"Here we go again!"* ]]; then
+    pass_test "reset function"
 else
     fail_test "reset function"
 fi
@@ -32,7 +39,7 @@ fi
 echo "Testing get_default_branch_name function..."
 default_branch=$(get_default_branch_name)
 if [[ "$default_branch" == "main" || "$default_branch" == "master" ]]; then
-    echo -e "\033[32m\033[1mget_default_branch_name function: PASS\033[0m"
+    pass_test "get_default_branch_name function"
 else
     fail_test "get_default_branch_name function"
 fi
@@ -41,7 +48,7 @@ fi
 echo "Testing init_exercise function..."
 init_exercise
 if [[ -d "$SCRIPT_DIR/../../../beginners_git" ]]; then
-    echo -e "\033[32m\033[1minit_exercise function: PASS\033[0m"
+    pass_test "init_exercise function"
 else
     fail_test "init_exercise function"
 fi
@@ -50,7 +57,7 @@ fi
 echo "Testing init_repo_empty_schedule function..."
 init_repo_empty_schedule
 if [[ -f "$SCRIPT_DIR/../../../beginners_git/conference_planning/conference_schedule.txt" ]]; then
-    echo -e "\033[32m\033[1minit_repo_empty_schedule function: PASS\033[0m"
+    pass_test "init_repo_empty_schedule function"
 else
     fail_test "init_repo_empty_schedule function"
 fi
@@ -59,7 +66,7 @@ fi
 echo "Testing init_simple_repo function..."
 init_simple_repo
 if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" ]]; then
-    echo -e "\033[32m\033[1minit_simple_repo function: PASS\033[0m"
+    pass_test "init_simple_repo function"
 else
     fail_test "init_simple_repo function"
 fi
@@ -68,7 +75,7 @@ fi
 echo "Testing init_simple_repo_remote function..."
 init_simple_repo_remote
 if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/.git" ]]; then
-    echo -e "\033[32m\033[1minit_simple_repo_remote function: PASS\033[0m"
+    pass_test "init_simple_repo_remote function"
 else
     fail_test "init_simple_repo_remote function"
 fi
@@ -77,7 +84,7 @@ fi
 echo "Testing init_repo function..."
 init_repo
 if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" ]]; then
-    echo -e "\033[32m\033[1minit_repo function: PASS\033[0m"
+    pass_test "init_repo function"
 else
     fail_test "init_repo function"
 fi
@@ -86,7 +93,7 @@ fi
 echo "Testing init_repo_remote function..."
 init_repo_remote
 if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" && -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/" ]]; then
-    echo -e "\033[32m\033[1minit_repo_remote function: PASS\033[0m"
+    pass_test "init_repo_remote function"
 else
     fail_test "init_repo_remote function"
 fi
@@ -95,7 +102,13 @@ fi
 echo "Testing commit_to_remote_by_third_party function..."
 commit_to_remote_by_third_party
 if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" && -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/" ]]; then
-    echo -e "\033[32m\033[1mcommit_to_remote_by_third_party function: PASS\033[0m"
+    pass_test "commit_to_remote_by_third_party function"
 else
     fail_test "commit_to_remote_by_third_party function"
 fi
+
+# Print summary
+echo -e "\n\033[1mTest Summary:\033[0m"
+for result in "${TEST_RESULTS[@]}"; do
+    echo -e "$result"
+done

--- a/beginner/tests/test_helpers.sh
+++ b/beginner/tests/test_helpers.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -e
+
+# Calculate the absolute path to helpers.sh
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HELPERS_PATH="$SCRIPT_DIR/../helpers.sh"
+
+if [ ! -f "$HELPERS_PATH" ]; then
+    echo -e "\033[31m\033[1mError: helpers.sh not found at $HELPERS_PATH\033[0m"
+    exit 1
+fi
+
+source "$HELPERS_PATH"
+
+# Function to handle test failures
+fail_test() {
+    echo -e "\033[31m\033[1m$1: FAIL\033[0m"
+    exit 1
+}
+
+# Test reset function
+echo "Testing reset function..."
+reset_output=$(reset)
+if [[ "$reset_output" == *"restore clean working directory"* ]]; then
+    echo -e "\033[32m\033[1mreset function: PASS\033[0m"
+else
+    fail_test "reset function"
+fi
+
+# Test get_default_branch_name function
+echo "Testing get_default_branch_name function..."
+default_branch=$(get_default_branch_name)
+if [[ "$default_branch" == "main" || "$default_branch" == "master" ]]; then
+    echo -e "\033[32m\033[1mget_default_branch_name function: PASS\033[0m"
+else
+    fail_test "get_default_branch_name function"
+fi
+
+# Test init_exercise function
+echo "Testing init_exercise function..."
+init_exercise
+if [[ -d "$SCRIPT_DIR/../../../beginners_git" ]]; then
+    echo -e "\033[32m\033[1minit_exercise function: PASS\033[0m"
+else
+    fail_test "init_exercise function"
+fi
+
+# Test init_repo_empty_schedule function
+echo "Testing init_repo_empty_schedule function..."
+init_repo_empty_schedule
+if [[ -f "$SCRIPT_DIR/../../../beginners_git/conference_planning/conference_schedule.txt" ]]; then
+    echo -e "\033[32m\033[1minit_repo_empty_schedule function: PASS\033[0m"
+else
+    fail_test "init_repo_empty_schedule function"
+fi
+
+# Test init_simple_repo function
+echo "Testing init_simple_repo function..."
+init_simple_repo
+if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" ]]; then
+    echo -e "\033[32m\033[1minit_simple_repo function: PASS\033[0m"
+else
+    fail_test "init_simple_repo function"
+fi
+
+# Test init_simple_repo_remote function
+echo "Testing init_simple_repo_remote function..."
+init_simple_repo_remote
+if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/.git" ]]; then
+    echo -e "\033[32m\033[1minit_simple_repo_remote function: PASS\033[0m"
+else
+    fail_test "init_simple_repo_remote function"
+fi
+
+# Test init_repo function
+echo "Testing init_repo function..."
+init_repo
+if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" ]]; then
+    echo -e "\033[32m\033[1minit_repo function: PASS\033[0m"
+else
+    fail_test "init_repo function"
+fi
+
+# Test init_repo_remote function
+echo "Testing init_repo_remote function..."
+init_repo_remote
+if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" && -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/" ]]; then
+    echo -e "\033[32m\033[1minit_repo_remote function: PASS\033[0m"
+else
+    fail_test "init_repo_remote function"
+fi
+
+# Test commit_to_remote_by_third_party function
+echo "Testing commit_to_remote_by_third_party function..."
+commit_to_remote_by_third_party
+if [[ -d "$SCRIPT_DIR/../../../beginners_git/conference_planning/.git" && -d "$SCRIPT_DIR/../../../beginners_git/conference_planning_remote/" ]]; then
+    echo -e "\033[32m\033[1mcommit_to_remote_by_third_party function: PASS\033[0m"
+else
+    fail_test "commit_to_remote_by_third_party function"
+fi


### PR DESCRIPTION
This PR replaces all occurrences of the `ed` command in the _beginner/helpers.sh_ script, because it was causing issues for Git Bash users that do not have `ed` installed. We replaced `ed` with `sed` for now.