### PR TITLE
Ex2: add numpy as requirement for script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Test
+
 # C2SM Git Courses
 
 ## Git Course for Beginners

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Test
-
 # C2SM Git Courses
 
 ## Git Course for Beginners

--- a/advanced/Exercise_2_git-bisect.md
+++ b/advanced/Exercise_2_git-bisect.md
@@ -123,6 +123,9 @@ We can also automate this process to make it easier. We just need a testing scri
   else:
       sys.exit(1)
   ```
+
+  Note: To use this script you need to have the [`numpy`](https://numpy.org/install/) package installed. 
+
 </details>
 
 Now that we have a script to check the code, let's use `git bisect run` to quickly find the bad commit in our repository.

--- a/advanced/Exercise_2_git-bisect.md
+++ b/advanced/Exercise_2_git-bisect.md
@@ -110,6 +110,8 @@ We can also automate this process to make it easier. We just need a testing scri
 <details>
   <summary>Click here to see contents of the code checking script</summary>
 
+  _Note_: To use this script you need to have the [`numpy`](https://numpy.org/install/) package installed.
+
   ```plaintext
   import subprocess
   import numpy
@@ -123,8 +125,6 @@ We can also automate this process to make it easier. We just need a testing scri
   else:
       sys.exit(1)
   ```
-
-  Note: To use this script you need to have the [`numpy`](https://numpy.org/install/) package installed. 
 
 </details>
 

--- a/advanced/Exercise_2_git-bisect.md
+++ b/advanced/Exercise_2_git-bisect.md
@@ -110,7 +110,8 @@ We can also automate this process to make it easier. We just need a testing scri
 <details>
   <summary>Click here to see contents of the code checking script</summary>
 
-  _Note_: To use this script you need to have the [`numpy`](https://numpy.org/install/) package installed.
+> [!NOTE]
+> To use this script you need to have the [`numpy`](https://numpy.org/install/) package installed.
 
   ```plaintext
   import subprocess

--- a/advanced/Exercise_2_git-bisect.md
+++ b/advanced/Exercise_2_git-bisect.md
@@ -125,7 +125,6 @@ We can also automate this process to make it easier. We just need a testing scri
   else:
       sys.exit(1)
   ```
-
 </details>
 
 Now that we have a script to check the code, let's use `git bisect run` to quickly find the bad commit in our repository.


### PR DESCRIPTION
In Exercise 2 for bisect, when using the given script for automatic bisection, the resulting 'bad' commit is wrong if numpy is not installed. 