### PR TITLE
Fix pre-commit script not preventing commit

### DIFF
--- a/advanced/Exercise_7_git-hooks.md
+++ b/advanced/Exercise_7_git-hooks.md
@@ -76,6 +76,9 @@ Integrate another *pre-commit* hook from the above repository into your workflow
 
 # This is the main pre-commit hook script.
 
+# Track whether any hook fails.
+# 0: all checks have passed so far; 
+# 1: at least one check failed.
 status=0
 
 # Run the whitespace check script.

--- a/advanced/Exercise_7_git-hooks.md
+++ b/advanced/Exercise_7_git-hooks.md
@@ -76,11 +76,15 @@ Integrate another *pre-commit* hook from the above repository into your workflow
 
 # This is the main pre-commit hook script.
 
+status=0
+
 # Run the whitespace check script.
-.git/hooks/pre-commit-whitespace
+.git/hooks/pre-commit-whitespace || status=1
 
 # Run the name and email verification script.
-.git/hooks/pre-commit-verify-name-and-email
+.git/hooks/pre-commit-verify-name-and-email || status=1
+
+exit $status
 ```
 
 > **Hint:** Don't forget that all scripts need to be executable! 


### PR DESCRIPTION
In Exercise 7, in the pre-commit script when the whitespace check script failed but the verify-name-and-email script didn't, then pre-commit exited without error and allowed the commit to go through.